### PR TITLE
Change call to build_attrs

### DIFF
--- a/flexibledatefield/fields.py
+++ b/flexibledatefield/fields.py
@@ -150,7 +150,7 @@ class FlexibleDateDescriptor(object):
 
 class FlexibleDateField(models.PositiveIntegerField):
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection, context=None):
         if value is None:
             return None
         return flexibledate.parse(value)

--- a/flexibledatefield/fields.py
+++ b/flexibledatefield/fields.py
@@ -45,7 +45,7 @@ class FlexibleDateWidget(forms.Widget):
         else:
             id_ = 'id_%s' % name
 
-        local_attrs = self.build_attrs(base_attrs={'id':self.year_field % id_})
+        local_attrs = self.build_attrs(base_attrs=self.attrs, extra_attrs={'id':self.year_field % id_})
         year_choices = [(i, i) for i in self.years]
         year_choices.reverse()
         if not self.required:

--- a/flexibledatefield/fields.py
+++ b/flexibledatefield/fields.py
@@ -45,7 +45,7 @@ class FlexibleDateWidget(forms.Widget):
         else:
             id_ = 'id_%s' % name
 
-        local_attrs = self.build_attrs(id=self.year_field % id_)
+        local_attrs = self.build_attrs(base_attrs={'id':self.year_field % id_})
         year_choices = [(i, i) for i in self.years]
         year_choices.reverse()
         if not self.required:


### PR DESCRIPTION
> The signature of private API Widget.build_attrs() changed from extra_attrs=None, **kwargs to base_attrs, extra_attrs=None.

https://docs.djangoproject.com/en/dev/releases/1.11/


More specifically https://github.com/django/django/commit/4bdc832a7598c1811c5a50fb39c912c02ce87a39

Also passing `self.attrs` as `base_attrs` seems to be preferable. Please advice if that should not be the case